### PR TITLE
fix: wrap buttons in parent container

### DIFF
--- a/src/resources/css/style.css
+++ b/src/resources/css/style.css
@@ -12,6 +12,12 @@ body {
     display: -webkit-inline-box;
     display: -webkit-inline-flex;
     display: inline-flex;
+    -webkit-flex-wrap: wrap;
+    -moz-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    -o-flex-wrap: wrap;
+    flex-wrap: wrap;
+    gap: 4px;
     border: 1px solid #CECFD1;
     border-radius: 4px;
     overflow: hidden;


### PR DESCRIPTION
This PR adjust the btn-group css that the buttons are wrapped inside their parent container and don't overflow.

Before:
![Bildschirmfoto 2021-09-01 um 11 39 51](https://user-images.githubusercontent.com/4366030/131651075-0f862a0c-827f-4498-93cd-7b4fcf023aef.png)

After:
![Bildschirmfoto 2021-09-01 um 11 46 15](https://user-images.githubusercontent.com/4366030/131651070-b3da4a49-19d7-4d53-8f55-0ab262eddbf8.png)

